### PR TITLE
Fix variable references for lastTime and cm in destroy()

### DIFF
--- a/code-blast.js
+++ b/code-blast.js
@@ -147,7 +147,7 @@ https://twitter.com/JoelBesada/status/670343885655293952
 
 		// get the time past the previous frame
 		var current_time = new Date().getTime();
-		if(!lastTime) last_time = current_time;
+		if(!lastTime) lastTime = current_time;
 		var dt = (current_time - lastTime) / 1000;
 		lastTime = current_time;
 
@@ -197,8 +197,8 @@ https://twitter.com/JoelBesada/status/670343885655293952
 
 
 	CodeMirror.defineOption("blastCode", false, function(c, val, old) {
+		cm = c;
 		if (val) {
-			cm = c;
 			cm.state.blastCode = true;
 			effect = val.effect || 2;
 			cmNode = cm.getWrapperElement();


### PR DESCRIPTION
Fixes for the following minor issues:
- The `lastTime` variable is checked, and if not present, `last_time` is initialized.
- If the blastCode option is falsey, but has not been initialized previously, the `destroy` function will attempt to refer to CodeMirror via `cm`, which will not have been set. 
